### PR TITLE
make flashrom follow stable branch, since master does not exist

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,4 @@
 [submodule "flashrom"]
 	path = flashrom
 	url = https://github.com/stefanct/flashrom.git
+	branch = stable


### PR DESCRIPTION
By default git submodule update --remote want origin/master but since flashrom does not have this at the moment, it should be stable or staging.
