### PR TITLE
Add support for 2 cheap ($2) STM32 Dev. boards called blue pill and r…

### DIFF
--- a/boards/stm32-bluepill.h
+++ b/boards/stm32-bluepill.h
@@ -1,0 +1,22 @@
+#ifndef __BOARD_H__
+#define __BOARD_H__
+
+#include <stdbool.h>
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/gpio.h>
+
+#define BOARD_USE_DEBUG_PINS_AS_GPIO false /* We don't have to disable SWD to access Gpio's on these boards */
+
+#define BOARD_RCC_LED                RCC_GPIOC
+#define BOARD_PORT_LED               GPIOC
+#define BOARD_PIN_LED                GPIO13
+#define BOARD_LED_HIGH_IS_BUSY       true
+
+#define BOARD_RCC_USB_PULLUP         RCC_GPIOA
+#define BOARD_PORT_USB_PULLUP        GPIOA
+#define BOARD_PIN_USB_PULLUP         GPIO12
+#define BOARD_USB_HIGH_IS_PULLUP     true
+
+/* Currently you can only use SPI1, since it has highest clock. */
+
+#endif /* __BOARD_H__ */

--- a/boards/stm32-bluepill.mk
+++ b/boards/stm32-bluepill.mk
@@ -1,0 +1,4 @@
+ARCH_FLAGS = -DSTM32F1 -mthumb -mcpu=cortex-m3 -msoft-float -mfix-cortex-m3-ldrd
+LDSCRIPT   = libopencm3/lib/stm32/f1/stm32f103x8.ld
+LIBOPENCM3 = libopencm3/lib/libopencm3_stm32f1.a
+OPENCM3_MK = lib/stm32/f1


### PR DESCRIPTION
…ed pill

Since red one is no more manufactured or sold, board support name is stm32-bluepill
You can build it with:
You can find more info in these links:
http://wiki.stm32duino.com/index.php?title=Blue_Pill
http://wiki.stm32duino.com/index.php?title=Red_Pill
SPI flash PINS:
PA6 &/or PB14 = MISO
PA7 &/or PB15 = MOSI
PA4 &/or PB12 = SS/CS
PA5 &/or PB13 = SCK
PA0 = WP/

Signed-off-by: demetris ierokipides.dem@gmail.com
