### PR TITLE
make flashrom follow staging branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 [submodule "flashrom"]
 	path = flashrom
 	url = https://github.com/stefanct/flashrom.git
-	branch = stable
+	branch = staging


### PR DESCRIPTION
Apparently the flashrom repo receives some heavy refactoring.
Building stm32-vserprog with the stable branch of flashrom doesn't work anymore, thus change it to staging.
