### PR TITLE
vserprog.c: Don't include <stdio.h>

### DIFF
--- a/vserprog.c
+++ b/vserprog.c
@@ -1,5 +1,4 @@
 #include <stdbool.h>
-#include <stdio.h>
 
 #include <libopencm3/stm32/rcc.h>
 #include <libopencm3/stm32/gpio.h>


### PR DESCRIPTION
There's no need to include it.