### PR TITLE
Add a Travis-CI script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: c
+dist: xenial
+addons:
+  apt:
+    packages:
+      - gcc-arm-none-eabi
+      - libnewlib-arm-none-eabi
+
+script:
+  - for board in $(ls boards/*.h | cut -d/ -f2 | cut -d. -f1); do
+      make BOARD="$board" || return 1;
+    done
+  - make distclean


### PR DESCRIPTION
Travis-CI can automatically build-test the code on every commit or pull request.

If you want to enable Travis-CI, you need to go to <https://travis-ci.org/>, log in with GitHub,  and enable the stm32-vserprog repo.