### PR TITLE
switch flashrom git url to mirror on GitHub

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,5 +4,5 @@
 	branch = master
 [submodule "flashrom"]
 	path = flashrom
-	url = https://www.flashrom.org/git/flashrom.git
+	url = https://github.com/flashrom/flashrom.git
 	branch = staging


### PR DESCRIPTION
The origin git host has moved to `https://review.coreboot.org/flashrom.git` .
Officially mirrored on GitHub.