### PR TITLE
Fix SPI baudrate for STM32F0 targets

### DIFF
--- a/spi.c
+++ b/spi.c
@@ -49,7 +49,6 @@ uint32_t spi_setup(uint32_t speed_hz) {
 
 #ifdef STM32F0
   rcc_periph_clock_enable(RCC_DMA);
-  uint32_t rcc_apb2_frequency = rcc_apb1_frequency; /* STM32F0x2 only has one APB. */
 #else
   rcc_periph_clock_enable(RCC_DMA1);
 #endif /* STM32F0 */


### PR DESCRIPTION
rcc.h provides a define for rcc_apb2_frequency which then collided with the local variable.
So after the preprocessor did its job, it looked like
uint32_t rcc_apb1_frequency = rcc_apb1_frequency;
As a result the SPI frequency was always 24MHz, no matter of the desired frequency.