### PR TITLE
bluepill: fix re-enumeration

### DIFF
--- a/boards/stm32-bluepill.h
+++ b/boards/stm32-bluepill.h
@@ -20,10 +20,15 @@
 #define BOARD_PIN_LED                GPIO13
 #define BOARD_LED_HIGH_IS_BUSY       true
 
+/*
+ * Pull USB D+ low on startup, to re-enumerate.
+ * Bluepill board lacks dedicated pin for handling this pull-up.
+ * https://stm32world.com/wiki/STM32_USB_Device_Renumeration
+ */
 #define BOARD_RCC_USB_PULLUP         RCC_GPIOA
 #define BOARD_PORT_USB_PULLUP        GPIOA
 #define BOARD_PIN_USB_PULLUP         GPIO12
-#define BOARD_USB_HIGH_IS_PULLUP     true
+#define BOARD_USB_HIGH_IS_PULLUP     false
 
 /* Currently you can only use SPI1, since it has highest clock. */
 


### PR DESCRIPTION
Fixes re-enumeration issues for me, even when booting from SRAM and pressing reset button repeatedly in various intervals and lengths. Resetting with OpenOCD `reset` command is also causing re-enumeration now.