### PR TITLE
Add new board: Nucleo-F042K6

### DIFF
--- a/boards/nucleo-f042k6.h
+++ b/boards/nucleo-f042k6.h
@@ -1,0 +1,44 @@
+#ifndef __BOARD_H__
+#define __BOARD_H__
+
+#include <stdbool.h>
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/gpio.h>
+
+/*
+ * Board definitions for ST's Nucleo-32 reference board with STM32F042K6
+ *      https://www.st.com/en/evaluation-tools/nucleo-f042k6.html
+ *
+ * The USB port on the board is connected to an onboard ST-LINK.
+ * F042's actual USB port is exposed on the pin headers:
+ * 
+ *  USB  | Nucleo pin
+ * ------|------------
+ *  D-   | D10
+ *  D+   | D2
+ *  5V   | 5V
+ *  GND  | GND
+ *
+ *  SPI  | Nucleo pin
+ * ------|------------
+ *  CS   | A3
+ *  SCK  | A4
+ *  MISO | A5
+ *  MOSI | A6
+ *
+ */
+
+#define BOARD_USE_DEBUG_PINS_AS_GPIO false
+
+#define BOARD_RCC_LED                RCC_GPIOB
+#define BOARD_PORT_LED               GPIOB
+#define BOARD_PIN_LED                GPIO3
+
+/* Only LED, high active, use as idle. */
+#define BOARD_LED_HIGH_IS_BUSY       false
+
+/* STM32F0x2 has internal USB pullup. */
+
+/* Currently you can only use SPI1, since it has highest clock. */
+
+#endif /* __BOARD_H__ */

--- a/boards/nucleo-f042k6.mk
+++ b/boards/nucleo-f042k6.mk
@@ -1,0 +1,4 @@
+ARCH_FLAGS = -DSTM32F0 -mthumb -mcpu=cortex-m0 -msoft-float
+LDSCRIPT   = boards/ld/stm32f04xz6.ld
+LIBOPENCM3 = libopencm3/lib/libopencm3_stm32f0.a
+OPENCM3_MK = lib/stm32/f0


### PR DESCRIPTION
Test setup:
Nucleo-F042K6 wired to an EN25F80 (1024kB) on a breadboard. RESET/HOLD and WP pulled to VCC.

flashrom -p serprog:dev=/dev/serprog1,spispeed=36M -w rand 8,49s user 1,00s system 47% cpu 20,069 total

flashrom -p serprog:dev=/dev/serprog1,spispeed=36M -v rand 1,20s user 0,02s system 50% cpu 2,442 total

flashrom -p serprog:dev=/dev/serprog1,spispeed=36M -E 8,84s user 0,09s system 84% cpu 10,594 total